### PR TITLE
Add asset revisioning with gulp-rev

### DIFF
--- a/buildsys/default-tasks.js
+++ b/buildsys/default-tasks.js
@@ -8,6 +8,7 @@ module.exports = [
   [
     'styles',
     'scripts',
-    'copy-assets'
+    'copy-assets',
+    'rev'
   ]
 ]

--- a/buildsys/tasks/clean.js
+++ b/buildsys/tasks/clean.js
@@ -1,0 +1,16 @@
+/**
+ * ./buildsys/tasks/clean.js
+ * @author Scott Roach
+ * ------------------------------------
+ * TASK: Clean
+ * 'gulp clean'
+ */
+
+var del = require('del')
+
+/* $ gulp clean */
+gulp.task('clean', function () {
+  if (env === 'prod') {
+    return del([config.paths.distRoot + '/**'])
+  }
+})

--- a/buildsys/tasks/clean.js
+++ b/buildsys/tasks/clean.js
@@ -12,5 +12,7 @@ var del = require('del')
 gulp.task('clean', function () {
   if (env === 'prod') {
     return del([config.paths.distRoot + '/**'])
+  } else {
+    return del([config.paths.distRoot + '/rev-manifest.json'])
   }
 })

--- a/buildsys/tasks/copy-assets.js
+++ b/buildsys/tasks/copy-assets.js
@@ -7,7 +7,7 @@
  */
 
 /* $ gulp copy-assets */
-gulp.task('copy-assets', function () {
+gulp.task('copy-assets', ['clean'], function () {
   return gulp.src(config.assets.paths.src + '/**/*.*')
     .pipe(gulp.dest(config.assets.paths.output))
 })

--- a/buildsys/tasks/rev.js
+++ b/buildsys/tasks/rev.js
@@ -1,0 +1,24 @@
+/**
+ * ./buildsys/tasks/rev.js
+ * @author Scott Roach
+ * ------------------------------------
+ * TASK: Rev
+ * 'gulp rev'
+ */
+
+var override = require('gulp-rev-css-url')
+var replace = require('gulp-replace')
+var rev = require('gulp-rev')
+
+/* $ gulp rev */
+gulp.task('rev', ['copy-assets', 'scripts', 'styles'], function () {
+  if (env === 'prod') {
+    return gulp.src(config.paths.distRoot + '/**')
+      .pipe(rev())
+      .pipe(override())
+      .pipe(gulp.dest(config.paths.distRoot))
+      .pipe(rev.manifest())
+      .pipe(replace(/(\s)\"/g, '$1"' + config.paths.distDocRoot))
+      .pipe(gulp.dest(config.paths.distRoot))
+  }
+})

--- a/buildsys/tasks/scripts.js
+++ b/buildsys/tasks/scripts.js
@@ -20,7 +20,7 @@ var buffer = require('vinyl-buffer')
 var srcScriptsGlob = config.scripts.paths.src + '/**/*.js'
 
 /* $ gulp scripts */
-gulp.task('scripts', function () {
+gulp.task('scripts', ['clean'], function () {
   return runSequence('scripts:lint', 'scripts:compile')
 })
 

--- a/buildsys/tasks/styles.js
+++ b/buildsys/tasks/styles.js
@@ -16,7 +16,7 @@ var plumber = require('gulp-plumber')
 var gulpif = require('gulp-if')
 
 /* $ gulp styles */
-gulp.task('styles', function () {
+gulp.task('styles', ['clean'], function () {
   var processors = [
     autoprefixer,
     lost

--- a/config.js
+++ b/config.js
@@ -6,12 +6,14 @@
 
 var srcRoot = './src'
 var distRoot = './dist'
+var docRoot = '/dist/'
 
 module.exports = {
   paths: {
     hollyRoot: __dirname,
     srcRoot: srcRoot,
-    distRoot: distRoot
+    distRoot: distRoot,
+    distDocRoot: docRoot
   },
   assets: {
     paths: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envoy-holly",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "ENVOYsites Gulp build system and boilerplate.",
   "scripts": {
     "init": "gulp init --local-dev --standalone",
@@ -27,11 +27,15 @@
     "bourbon-neat": "^1.8.0",
     "browserify": "^14.1.0",
     "cssnano": "^3.10.0",
+    "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-batch-replace": "^0.0.0",
     "gulp-if": "^2.0.2",
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.3.0",
+    "gulp-replace": "^0.5.4",
+    "gulp-rev": "^7.1.2",
+    "gulp-rev-css-url": "^0.1.0",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.4.1",
     "gulp-standard": "^8.0.3",


### PR DESCRIPTION
Clean out the dist directory on prod builds, then after all other tasks are finished we run the revisioning code.

This adds some inter-task dependencies, can't find away around that.